### PR TITLE
Support ascii-based QR code option

### DIFF
--- a/pretexts/mfa/qrcode_ascii_email.html
+++ b/pretexts/mfa/qrcode_ascii_email.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+
+<body>
+    <div style="background-color:#eee;padding:10px 20px;">
+        <h2 style="font-family:Georgia, 'Times New Roman', Times, serif; color: #454349;">Microsoft Authenticator Update Needed</h2>
+    </div>
+    <div style="padding:20px 0px">
+        <div style="height: 500px;width:400px">
+            <p> Your Microsoft Authenticator token has expired. Please scan the QR code below to generate a new
+                device code for your Microsoft Authenticator App.</p>
+            <p> The code will be emailed to you, and you should enter it at
+                <a
+                    href="https://login.microsoftonline.com/common/oauth2/deviceauth">https://login.microsoftonline.com/common/oauth2/deviceauth</a>
+            </p>
+            <div style="word-spacing:normal;">
+            <div style="margin:0px auto;max-width:600px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%%;">
+                <tbody>
+                    <tr>
+                        <td align='center' style='mso-line-height-rule: exactly;line-height: 90%%;font-size: 1.8pt; font-family: "Courier New"; color: black'>
+                            %s
+                        </td>                    
+                    </tr>
+                </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/settings.config
+++ b/settings.config
@@ -12,6 +12,7 @@ SQUAREPHISH_ENDPOINT = "/mfa"                                                   
 FROM_EMAIL           = "admin@square.phish"                                                     # Default FROM address when sending an email
 SUBJECT              = "ACTION REQUIRED: Multi-Factor Authentication (MFA) Update"              # Default SUBJECT when sending an email, defauled to an MFA pretext
 EMAIL_TEMPLATE       = "pretexts/mfa/qrcode_email.html"                                         # Email body template for QR code email to victim
+QRCODE_ASCII         = "false"                                                                  # Send qrcode as ascii art
 
 [SERVER]
 PORT                 = 8443

--- a/squarephish/modules/qrcode/email.py
+++ b/squarephish/modules/qrcode/email.py
@@ -58,6 +58,44 @@ class QRCodeEmail:
             logging.error(f"Error generating QR code: {e}")
             return None
 
+    def _generate_qrcode_ascii(
+            self,
+            server: str,
+            port: int,
+            endpoint: str,
+            email: str,
+            url: str,
+        ) -> str:
+            """Generate an ASCII QR code for a given URL
+
+            :param server:   malicious server domain/IP
+            :param port:     port malicious server is running on
+            :param endpoint: malicious server endpoint to request
+            :param email:    TO email address of victim
+            :param url:      URL if over riding default
+            :returns:        ASCII QR code HTML snippet
+            """
+            try:
+                endpoint = endpoint.strip("/")
+                if url is None:
+                    url = f"https://{server}:{port}/{endpoint}?email={email}"
+                    
+                qrcode = pyqrcode.create(url)
+                ascii_qrcode = ""
+                for c in qrcode.text():
+                    if c == "\n":
+                        ascii_qrcode += "<br/>\n"
+                    elif c == "1":
+                        ascii_qrcode += "██"
+                    else:
+                        ascii_qrcode += "&nbsp;&nbsp;"
+
+                return ascii_qrcode
+
+            except Exception as e:
+                logging.error(f"Error generating ASCII QR code: {e}")
+                return None
+
     @classmethod
     def send_qrcode(
         cls,
@@ -71,37 +109,58 @@ class QRCodeEmail:
         :param email:   target victim email address to send email to
         :param config:  configuration settings
         :param emailer: emailer object to send emails
+        :param ascii:   enable ascii QR code generation
         :returns:       bool if the email was successfully sent
         """
-        qrcode = cls._generate_qrcode(
-            cls,
-            config.get("EMAIL", "SQUAREPHISH_SERVER"),
-            config.get("EMAIL", "SQUAREPHISH_PORT"),
-            config.get("EMAIL", "SQUAREPHISH_ENDPOINT"),
-            email,
-            url,
-        )
-
-        if not qrcode:
-            logging.error("Failed to generate QR code")
-            return False
-
         msg = EmailMessage()
         msg["To"] = email
         msg["From"] = config.get("EMAIL", "FROM_EMAIL")
-        msg["Subject"] = config.get("EMAIL", "SUBJECT")
+        msg["Subject"] = config.get("EMAIL", "SUBJECT")        
 
         email_template = config.get("EMAIL", "EMAIL_TEMPLATE")
-        msg.set_content(email_template, subtype="html")
-        msg.add_alternative(email_template, subtype="html")
+        
+        # Handle ASCII QR Code
+        if config.get("EMAIL", "QRCODE_ASCII") == "true":
+            qrcode = cls._generate_qrcode_ascii(
+                cls,
+                config.get("EMAIL", "SQUAREPHISH_SERVER"),
+                config.get("EMAIL", "SQUAREPHISH_PORT"),
+                config.get("EMAIL", "SQUAREPHISH_ENDPOINT"),
+                email,
+                url,
+            )
 
-        # Create a new MIME image to embed into the email as inline
-        logo = MIMEImage(qrcode)
-        logo.add_header("Content-ID", f"<qrcode.png>")  # <img src"cid:qrcode.png">
-        logo.add_header("X-Attachment-Id", "qrcode.png")
-        logo["Content-Disposition"] = f"inline; filename=qrcode.png"
+            if not qrcode:
+                logging.error("Failed to generate ASCII QR code")
+                return False
+            
+            msg.set_content(email_template % qrcode, subtype="html")
 
-        msg.get_payload()[1].make_mixed()
-        msg.get_payload()[1].attach(logo)
+        # Handle QR Code image
+        else:
+            msg.set_content(email_template, subtype="html")
+            msg.add_alternative(email_template, subtype="html")
+
+            qrcode = cls._generate_qrcode(
+                cls,
+                config.get("EMAIL", "SQUAREPHISH_SERVER"),
+                config.get("EMAIL", "SQUAREPHISH_PORT"),
+                config.get("EMAIL", "SQUAREPHISH_ENDPOINT"),
+                email,
+                url,
+            )
+
+            if not qrcode:
+                logging.error("Failed to generate QR code")
+                return False
+
+            # Create a new MIME image to embed into the email as inline
+            logo = MIMEImage(qrcode)
+            logo.add_header("Content-ID", f"<qrcode.png>")  # <img src"cid:qrcode.png">
+            logo.add_header("X-Attachment-Id", "qrcode.png")
+            logo["Content-Disposition"] = f"inline; filename=qrcode.png"
+
+            msg.get_payload()[1].make_mixed()
+            msg.get_payload()[1].attach(logo)
 
         return emailer.send_email(msg)


### PR DESCRIPTION
Added ascii-based QR code option.

To use it, change the settings.config as follows

```
[EMAIL]
...
EMAIL_TEMPLATE       = "pretexts/mfa/ascii_qrcode_email.html"                                         # Email body template for QR code email to victim
QRCODE_ASCII         = "true"                                                                   # Send qrcode as ascii art
```

Then, you can send ascii-based QR code to a vitim.

![image](https://github.com/nromsdahl/squarephish/assets/166495968/36d9df9f-a125-4929-880b-7c211783b56b)


